### PR TITLE
Balance resources and costs

### DIFF
--- a/game/render/terrain.go
+++ b/game/render/terrain.go
@@ -131,10 +131,11 @@ func (s *Terrain) drawCursor(img *ebiten.Image,
 		canBuildHere := prop.BuildOn.Contains(ter)
 		if prop.IsTerrain {
 			height = 0
+			s.drawSprite(img, &s.terrain.Grid, x, y, toBuild, point, height, camOffset)
 		} else {
 			canBuildHere = canBuildHere && luEntity.IsZero()
+			s.drawSprite(img, &s.landUse.Grid, x, y, toBuild, point, height, camOffset)
 		}
-		s.drawSprite(img, &s.landUse.Grid, x, y, toBuild, point, height, camOffset)
 		if canBuildHere {
 			s.drawCursorSprite(img, point, camOffset, s.cursorGreen)
 		} else {

--- a/game/res/ui.go
+++ b/game/res/ui.go
@@ -183,7 +183,9 @@ func (ui *UI) createUI(sprites *Sprites) *widget.Container {
 func (ui *UI) CreateRandomButtons(randomTerrains int) {
 	if len(ui.RandomTerrains) == 0 {
 		for i := 0; i < randomTerrains; i++ {
-			ui.createRandomButton()
+			button, id := ui.createButton(terr.Grass)
+			ui.randomButtonsContainer.AddChild(button)
+			ui.randomButtons[id] = randomButton{terr.Grass, button}
 		}
 		ui.updateRandomTerrains()
 	} else {

--- a/game/terr/terrain.go
+++ b/game/terr/terrain.go
@@ -191,8 +191,7 @@ var Properties = [EndTerrain]TerrainProps{
 		CanBuy:     true,
 		Production: Production{Produces: resource.Stones, RequiredLandUse: Path, ProductionLandUse: Rock, ConsumesFood: 5},
 		BuildCost: []BuildCost{
-			{resource.Wood, 5},
-			{resource.Stones, 1},
+			{resource.Wood, 10},
 		},
 	},
 	{Name: "warehouse", IsTerrain: false,

--- a/game/terr/terrain.go
+++ b/game/terr/terrain.go
@@ -211,6 +211,6 @@ var RandomTerrain = []Terrain{
 	Grass, Grass, Grass, Grass, Grass, Grass, Grass, Grass, Grass, Grass,
 	Water, Water, Water, Water,
 	Desert,
-	Tree, Tree, Tree, Tree, Tree, Tree,
+	Tree, Tree, Tree, Tree,
 	Rock,
 }

--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 		WorldSize:      128,
 		RandomTerrains: 5,
 
-		InitialResources:  [3]int{25, 25, 10},
+		InitialResources:  [3]int{25, 25, 25},
 		StockPerWarehouse: [3]int{25, 25, 25},
 	}
 	ecs.AddResource(&g.Model.World, &rules)


### PR DESCRIPTION
- mason costs no stones
- more stones at start
- only grass tiles at start
- reduce probability of trees