### PR TITLE
Allow to build over natural land use

### DIFF
--- a/game/render/terrain.go
+++ b/game/render/terrain.go
@@ -203,7 +203,8 @@ func (s *Terrain) drawCursor(img *ebiten.Image,
 		if prop.IsTerrain {
 			height = 0
 		} else {
-			canBuildHere = canBuildHere && luEntity.IsZero()
+			luNatural := !terr.Properties[lu].CanBuy
+			canBuildHere = canBuildHere && luNatural
 		}
 		s.drawSprite(img, s.terrain, s.landUse, x, y, toBuild, point, height, camOffset, nil, true, prop.Below)
 

--- a/game/sys/build.go
+++ b/game/sys/build.go
@@ -97,9 +97,6 @@ func (s *Build) Update(world *ecs.World) {
 		}
 		return
 	}
-	if landUse.Get(cursor.X, cursor.Y) != terr.Air {
-		return
-	}
 
 	if !stock.CanPay(p.BuildCost) {
 		return
@@ -121,6 +118,17 @@ func (s *Build) Update(world *ecs.World) {
 	} else {
 		if !p.BuildOn.Contains(terrHere) {
 			return
+		}
+
+		luHere := landUse.Get(cursor.X, cursor.Y)
+		if terr.Properties[luHere].CanBuy {
+			return
+		}
+
+		if luHere != terr.Air {
+			landUse.Set(cursor.X, cursor.Y, terr.Air)
+			world.RemoveEntity(landUseE.Get(cursor.X, cursor.Y))
+			landUseE.Set(cursor.X, cursor.Y, ecs.Entity{})
 		}
 		fac.Set(world, cursor.X, cursor.Y, sel.BuildType)
 	}


### PR DESCRIPTION
Everything that can be bought can be built over natural (land use) features (i.e., trees and rocks).
If required, things can be cleared by building and removing a road, which costs 2x 1 wood.

Allows wo place trees and rocks way more freely. Makes larger scale landscaping for later colonization much more favorable.

Fixes #46