### PR TITLE
Add timer to track total play time

### DIFF
--- a/game/res/ui.go
+++ b/game/res/ui.go
@@ -411,7 +411,7 @@ func (ui *UI) createHUD(font font.Face) *widget.Container {
 	ui.populationLabel = counter
 
 	labelTimer := widget.NewText(
-		widget.TextOpts.Text("  Time", font, color.White),
+		widget.TextOpts.Text("   ", font, color.White),
 		widget.TextOpts.Position(widget.TextPositionCenter, widget.TextPositionCenter),
 	)
 	infoContainer.AddChild(labelTimer)

--- a/game/res/ui.go
+++ b/game/res/ui.go
@@ -38,6 +38,7 @@ type UI struct {
 	saveEvent       *SaveEvent
 	resourceLabels  []*widget.Text
 	populationLabel *widget.Text
+	timerLabel      *widget.Text
 	terrainButtons  []*widget.Button
 
 	buttonImages           []widget.ButtonImage
@@ -68,6 +69,10 @@ func (ui *UI) SetResourceLabel(id resource.Resource, text string) {
 
 func (ui *UI) SetPopulationLabel(text string) {
 	ui.populationLabel.Label = text
+}
+
+func (ui *UI) SetTimerLabel(text string) {
+	ui.timerLabel.Label = text
 }
 
 func (ui *UI) SetButtonEnabled(id terr.Terrain, enabled bool) {
@@ -404,6 +409,18 @@ func (ui *UI) createHUD(font font.Face) *widget.Container {
 	)
 	infoContainer.AddChild(counter)
 	ui.populationLabel = counter
+
+	labelTimer := widget.NewText(
+		widget.TextOpts.Text("  Time", font, color.White),
+		widget.TextOpts.Position(widget.TextPositionCenter, widget.TextPositionCenter),
+	)
+	infoContainer.AddChild(labelTimer)
+	counterTimer := widget.NewText(
+		widget.TextOpts.Text("0", font, color.White),
+		widget.TextOpts.Position(widget.TextPositionCenter, widget.TextPositionCenter),
+	)
+	infoContainer.AddChild(counterTimer)
+	ui.timerLabel = counterTimer
 
 	topBar.AddChild(menuContainer)
 	topBar.AddChild(innerAnchor)

--- a/game/sys/update_stats.go
+++ b/game/sys/update_stats.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mlange-42/tiny-world/game/res"
 	"github.com/mlange-42/tiny-world/game/resource"
 	"github.com/mlange-42/tiny-world/game/terr"
+	"github.com/mlange-42/tiny-world/game/util"
 )
 
 // UpdateStats system.
@@ -103,7 +104,8 @@ func (s *UpdateStats) Update(world *ecs.World) {
 	ui.SetPopulationLabel(fmt.Sprintf("%d/%d", stock.Population, stock.MaxPopulation))
 
 	secs := tick / interval
-	ui.SetTimerLabel(fmt.Sprint(time.Duration(secs) * time.Second))
+	duration := time.Duration(secs) * time.Second
+	ui.SetTimerLabel(fmt.Sprint(util.Format(duration, "15:04")))
 
 	for i := range terr.Properties {
 		props := &terr.Properties[i]

--- a/game/sys/update_stats.go
+++ b/game/sys/update_stats.go
@@ -103,7 +103,7 @@ func (s *UpdateStats) Update(world *ecs.World) {
 	ui.SetPopulationLabel(fmt.Sprintf("%d/%d", stock.Population, stock.MaxPopulation))
 
 	secs := tick / interval
-	ui.SetTimerLabel(fmt.Sprint(time.Duration(secs)*time.Second))
+	ui.SetTimerLabel(fmt.Sprint(time.Duration(secs) * time.Second))
 
 	for i := range terr.Properties {
 		props := &terr.Properties[i]

--- a/game/sys/update_stats.go
+++ b/game/sys/update_stats.go
@@ -2,6 +2,7 @@ package sys
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/mlange-42/arche/ecs"
 	"github.com/mlange-42/arche/generic"
@@ -17,6 +18,8 @@ type UpdateStats struct {
 	production generic.Resource[res.Production]
 	stock      generic.Resource[res.Stock]
 	ui         generic.Resource[res.UI]
+	tick       generic.Resource[res.GameTick]
+	interval   generic.Resource[res.UpdateInterval]
 
 	prodFilter              generic.Filter1[comp.Production]
 	consFilter              generic.Filter1[comp.Consumption]
@@ -31,6 +34,8 @@ func (s *UpdateStats) Initialize(world *ecs.World) {
 	s.production = generic.NewResource[res.Production](world)
 	s.stock = generic.NewResource[res.Stock](world)
 	s.ui = generic.NewResource[res.UI](world)
+	s.tick = generic.NewResource[res.GameTick](world)
+	s.interval = generic.NewResource[res.UpdateInterval](world)
 
 	s.prodFilter = *generic.NewFilter1[comp.Production]()
 	s.consFilter = *generic.NewFilter1[comp.Consumption]()
@@ -46,6 +51,8 @@ func (s *UpdateStats) Update(world *ecs.World) {
 	production := s.production.Get()
 	stock := s.stock.Get()
 	production.Reset()
+	tick := s.tick.Get().Tick
+	interval := s.interval.Get().Interval
 
 	prodQuery := s.prodFilter.Query(world)
 	for prodQuery.Next() {
@@ -94,6 +101,9 @@ func (s *UpdateStats) Update(world *ecs.World) {
 		}
 	}
 	ui.SetPopulationLabel(fmt.Sprintf("%d/%d", stock.Population, stock.MaxPopulation))
+
+	secs := tick / interval
+	ui.SetTimerLabel(fmt.Sprint(time.Duration(secs)*time.Second))
 
 	for i := range terr.Properties {
 		props := &terr.Properties[i]

--- a/game/util/format.go
+++ b/game/util/format.go
@@ -1,0 +1,7 @@
+package util
+
+import "time"
+
+func Format(dur time.Duration, format string) string {
+	return time.Unix(0, 0).UTC().Add(time.Duration(dur)).Format(format)
+}


### PR DESCRIPTION
The timer measures the playing time since the start of the game. The timer pauses when the game is paused. The time is displayed in the status bar at the top.

Fixes #92