### PR TITLE
Change cheats to require Ctrl+Alt+Shift

### DIFF
--- a/game/sys/cheats.go
+++ b/game/sys/cheats.go
@@ -26,6 +26,7 @@ func (s *Cheats) Initialize(world *ecs.World) {
 func (s *Cheats) Update(world *ecs.World) {
 	if ebiten.IsKeyPressed(ebiten.KeyShift) &&
 		ebiten.IsKeyPressed(ebiten.KeyControl) &&
+		ebiten.IsKeyPressed(ebiten.KeyAlt) &&
 		inpututil.IsKeyJustPressed(ebiten.KeyR) {
 
 		stock := s.stock.Get()
@@ -35,6 +36,7 @@ func (s *Cheats) Update(world *ecs.World) {
 
 	if ebiten.IsKeyPressed(ebiten.KeyShift) &&
 		ebiten.IsKeyPressed(ebiten.KeyControl) &&
+		ebiten.IsKeyPressed(ebiten.KeyAlt) &&
 		inpututil.IsKeyJustPressed(ebiten.KeyN) {
 
 		ui := s.ui.Get()


### PR DESCRIPTION
It browsers, the old cheats were the same as the shortcuts for (R) Page reload and (N) new window.