### PR TITLE
Fix cobra mouse trap, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,21 @@ Made with [Ebitengine](https://github.com/hajimehoshi/ebiten) and the [Arche](ht
 
 You can play Tiny World in a web browser [here](https://mlange-42.github.io/tiny-world/) or [on itch.io](https://mlange-42.itch.io/tiny-world).
 
-### Play locally
+### Precompiled binaries
 
-Until there is a first official release, you need to clone the repository and run the game with [Go](https://go.dev):
+You can download precompiled binaries for Linux and Windows from the [Releases](https://github.com/mlange-42/tiny-world/releases).
+
+### Build from source
+
+Clone the repository and build or run the game with [Go](https://go.dev):
 
 ```shell
 git clone https://github.com/mlange-42/tiny-world.git
 cd tiny-world
 go run .
 ```
+
+For building on Unix systems, `libgl1-mesa-dev` and `xorg-dev` are required.
 
 ## Playing
 

--- a/game/run_nowasm.go
+++ b/game/run_nowasm.go
@@ -11,6 +11,7 @@ import (
 )
 
 func run(g *Game, name string, load bool) {
+	cobra.MousetrapHelpText = ""
 	if err := command(g, name, load).Execute(); err != nil {
 		fmt.Printf("ERROR: %s\n", err.Error())
 		os.Exit(1)


### PR DESCRIPTION
* disable cobra mouse trap, which prevented start from Windows Explorer
* update README for precompiled binaries